### PR TITLE
feat: ability to directly write the gRPC frame to the ServerWritableStream

### DIFF
--- a/packages/grpc-js/src/object-stream.ts
+++ b/packages/grpc-js/src/object-stream.ts
@@ -49,9 +49,9 @@ export interface IntermediateObjectWritable<T> extends Writable {
 }
 
 export interface ObjectWritable<T> extends IntermediateObjectWritable<T> {
-  _write(chunk: T | Buffer, encoding: string, callback: Function): void;
-  write(chunk: T | Buffer, cb?: Function): boolean;
-  write(chunk: T | Buffer, encoding?: any, cb?: Function): boolean;
+  _write(chunk: T, encoding: string, callback: Function): void;
+  write(chunk: T, cb?: Function): boolean;
+  write(chunk: T, encoding?: any, cb?: Function): boolean;
   setDefaultEncoding(encoding: string): this;
   end(): ReturnType<Writable['end']> extends Writable ? this : void;
   end(

--- a/packages/grpc-js/src/object-stream.ts
+++ b/packages/grpc-js/src/object-stream.ts
@@ -49,9 +49,9 @@ export interface IntermediateObjectWritable<T> extends Writable {
 }
 
 export interface ObjectWritable<T> extends IntermediateObjectWritable<T> {
-  _write(chunk: T, encoding: string, callback: Function): void;
-  write(chunk: T, cb?: Function): boolean;
-  write(chunk: T, encoding?: any, cb?: Function): boolean;
+  _write(chunk: T | Buffer, encoding: string, callback: Function): void;
+  write(chunk: T | Buffer, cb?: Function): boolean;
+  write(chunk: T | Buffer, encoding?: any, cb?: Function): boolean;
   setDefaultEncoding(encoding: string): this;
   end(): ReturnType<Writable['end']> extends Writable ? this : void;
   end(

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -669,7 +669,7 @@ export class Http2ServerCallStream<
   serializeMessage(value: ResponseType | Buffer) {
     // TODO(cjihrig): Call compression aware serializeMessage().
 
-    if (value instanceof Buffer) {
+    if (Buffer.isBuffer(value)) {
       return this.serializeMessageHandleBuffer(value);
     }
 

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -90,6 +90,16 @@ export type ServerSurfaceCall = {
   getPath(): string;
 } & EventEmitter;
 
+export type ServerWritableBuffer<ResponseType> = {
+  _write(
+    chunk: ResponseType | Buffer,
+    encoding: string,
+    callback: Function
+  ): void;
+  write(chunk: ResponseType | Buffer, cb?: Function): boolean;
+  write(chunk: ResponseType | Buffer, encoding?: any, cb?: Function): boolean;
+};
+
 export type ServerUnaryCall<RequestType, ResponseType> = ServerSurfaceCall & {
   request: RequestType;
 };
@@ -97,13 +107,15 @@ export type ServerReadableStream<RequestType, ResponseType> =
   ServerSurfaceCall & ObjectReadable<RequestType>;
 export type ServerWritableStream<RequestType, ResponseType> =
   ServerSurfaceCall &
-    ObjectWritable<ResponseType> & {
+    ObjectWritable<ResponseType> &
+    ServerWritableBuffer<ResponseType> & {
       request: RequestType;
       end: (metadata?: Metadata) => void;
     };
 export type ServerDuplexStream<RequestType, ResponseType> = ServerSurfaceCall &
   ObjectReadable<RequestType> &
-  ObjectWritable<ResponseType> & { end: (metadata?: Metadata) => void };
+  ObjectWritable<ResponseType> &
+  ServerWritableBuffer<ResponseType> & { end: (metadata?: Metadata) => void };
 
 export class ServerUnaryCallImpl<RequestType, ResponseType>
   extends EventEmitter

--- a/packages/grpc-js/src/server-call.ts
+++ b/packages/grpc-js/src/server-call.ts
@@ -222,7 +222,7 @@ export class ServerWritableStreamImpl<RequestType, ResponseType>
   }
 
   _write(
-    chunk: ResponseType,
+    chunk: ResponseType | Buffer,
     encoding: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     callback: (...args: any[]) => void
@@ -654,15 +654,38 @@ export class Http2ServerCallStream<
     }
   }
 
-  serializeMessage(value: ResponseType) {
-    const messageBuffer = this.handler.serialize(value);
-
+  serializeMessage(value: ResponseType | Buffer) {
     // TODO(cjihrig): Call compression aware serializeMessage().
-    const byteLength = messageBuffer.byteLength;
+
+    if (value instanceof Buffer) {
+      return this.serializeMessageHandleBuffer(value);
+    }
+
+    const messageBuffer = this.handler.serialize(value);
+    return this.addCompressionAndLength(messageBuffer);
+  }
+
+  private serializeMessageHandleBuffer(value: Buffer): Buffer {
+    const byteLength = value.byteLength;
+    // checking if this is a protobuf message or a gRPC frame
+    if (
+      byteLength >= 5 &&
+      (value.readUInt8(0) === 0 || value.readUint8(0) === 1) &&
+      value.readUInt32BE(1) === byteLength - 5
+    ) {
+      return value;
+    }
+
+    return this.addCompressionAndLength(value);
+  }
+
+  private addCompressionAndLength(value: Buffer, compressed = false) {
+    const byteLength = value.byteLength;
+    const compressionByte = compressed ? 1 : 0;
     const output = Buffer.allocUnsafe(byteLength + 5);
-    output.writeUInt8(0, 0);
+    output.writeUInt8(compressionByte, 0);
     output.writeUInt32BE(byteLength, 1);
-    messageBuffer.copy(output, 5);
+    value.copy(output, 5);
     return output;
   }
 


### PR DESCRIPTION
Hello!
For some high-load purposes, I suggest implementing the ability to directly write the protobuf message or a gRPC frame to the ServerWritableStream.

My usecase:

I have a service that stores data in memory, shares it with its clients, and keeps their cache consistent with updates notification like  [etcd watch](https://etcd.io/docs/v3.6/dev-guide/interacting_v3/#watch-historical-changes-of-keys) . 

Its feature is the thousands of clients that can often make a "watch" request (server streaming rpc) with a large first response and infrequent small responses after it.

Since data updates happen quite infrequently, it makes sense to cache gRPC response frames instead of recalculating them each time.

For now I have implemented this as a hack in my code and it has saved me a lot of CPU time and RAM, especially `arrayBuffers`. Response time has been reduced tenfold for large messages. (_Along with serialization and memory allocations, I got rid of the long iterative process of collecting the requested data from my cache_)

---
_a bit of code prompted me to create this pull request_

```proto
service SomeService {
    rpc Watch(WatchRequest) returns (stream WatchResponse);
}
```
I used this extension of available types and created a function to skip serialization at runtime.
```ts
type HackBuf = {
    write(chunk: WatchResponse): boolean;
    write(chunk: WatchResponse | Buffer, encoding: 'buffer'): boolean;
};
type HackHttp2Buf = { call?: { serializeMessage: (r: WatchResponse) => Buffer } };
export type HackedWritableBuf = ServerWritableStream<WatchRequest, WatchResponse> & HackBuf & HackHttp2Buf;

const createFakeSerializer = (ctx: HackHttp2Buf): ((r: WatchResponse | Buffer) => Buffer) => {
    const orig = ctx.call!.serializeMessage;
    const binded = orig.bind(ctx.call);
    return (r) => (r instanceof Buffer ? r : binded(r));
};
```

Using a serializer generated from protobufjs and the serializeMessage method on ServerWritableStream I got this monster:
```ts
const SerializeWatchResponse = (v: WatchResponse): Buffer => {
    const ww = new Writer();
    ww.uint32(0).uint32(0).uint32(0).uint32(0).uint32(0);
    const out = Buffer.from(WatchResponse.encode(v, ww).finish());
    out.writeUInt8(0, 0);
    out.writeUInt32BE(out.length - 5, 1);
    return out;
};
```
It has only one buffer allocation instead of two when the gRPC frame serializer grpc and the protobuf message serializer are separated.


So now we can change serializer and write buffer instead of JS object.
```ts
const watch = (call: HackedWritableBuf) => {
    // ... some code ...
    call.call!.serializeMessage = createFakeSerializer(call);
    const frame = SerializeWatchResponse(WatchResponceExample)
    call.write(frame, 'buffer')
    // ... some code ...
};
```

So, I tried to make it less hacky. I am not entirely sure whether it is worth allowing not only a gRPC frame, but also a protobuf message (or any other format implemented in a buffer) to be passed to the write method, since they are difficult to distinguish from each other - checking the first five bytes does not look like definition for sure.

Thanks for any ideas or advice.


